### PR TITLE
Set node.js version to 18.x to allow deployment on Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "license": "MIT",
   "dependencies": {
     "serverlesswp": "^0.1.2"
+  },
+  "engines": {
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
Should resolve the following error and allow Serverless Functions to run without returning 500

```
/var/task/node_modules/serverlesswp/php-files/php: error while loading shared libraries: libssl.so.10: cannot open shared object file: No such file or directory
```